### PR TITLE
Eatt usage

### DIFF
--- a/include/bluetooth/att.h
+++ b/include/bluetooth/att.h
@@ -65,6 +65,12 @@ size_t bt_eatt_count(struct bt_conn *conn);
 #endif /* CONFIG_BT_TESTING */
 #endif /* CONFIG_BT_EATT */
 
+enum bt_att_chan_option {
+	BT_ATT_CHAN_UNENHANCED,
+	BT_ATT_CHAN_ENHANCED,
+	BT_ATT_CHAN_ANY,
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1537,6 +1537,29 @@ struct bt_gatt_write_params {
  */
 int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
 
+/** @brief GATT Write Without Response parameters */
+struct bt_gatt_write_without_rsp_params {
+	/** Transmission complete callback. */
+	bt_gatt_complete_func_t func;
+	/** Whether to sign data */
+	bool sign;
+	/** Attribute handle. */
+	uint16_t handle;
+	/** Data to be written. */
+	const void *data;
+	/** Data length. */
+	uint16_t length;
+	/** User data to be passed back to callback. */
+	void *user_data;
+#ifdef CONFIG_BT_EATT
+	enum bt_att_chan_option chan_option;
+#endif /* CONFIG_BT_EATT */
+};
+
+/* TODO: Add docs */
+int bt_gatt_write_without_rsp(struct bt_conn *conn,
+			      struct bt_gatt_write_without_rsp_params *params);
+
 /** @brief Write Attribute Value by handle without response with callback.
  *
  *  This function works in the same way as @ref bt_gatt_write_without_response.
@@ -1572,6 +1595,7 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *  outside the BT RX thread to get blocking behavior. Queue size is controlled
  *  by @kconfig{CONFIG_BT_L2CAP_TX_BUF_COUNT}.
  */
+__deprecated
 int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 				      const void *data, uint16_t length,
 				      bool sign, bt_gatt_complete_func_t func,
@@ -1598,6 +1622,7 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
  *  outside the BT RX thread to get blocking behavior. Queue size is controlled
  *  by @kconfig{CONFIG_BT_L2CAP_TX_BUF_COUNT}.
  */
+__deprecated
 static inline int bt_gatt_write_without_response(struct bt_conn *conn,
 						 uint16_t handle, const void *data,
 						 uint16_t length, bool sign)

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -981,6 +981,9 @@ struct bt_gatt_notify_params {
 	bt_gatt_complete_func_t func;
 	/** Notification Value callback user data */
 	void *user_data;
+#ifdef CONFIG_BT_EATT
+	enum bt_att_chan_option chan_option;
+#endif /* CONFIG_BT_EATT */
 };
 
 /** @brief Notify attribute value change.
@@ -1131,6 +1134,9 @@ struct bt_gatt_indicate_params {
 	uint16_t len;
 	/** Private reference counter */
 	uint8_t _ref;
+#ifdef CONFIG_BT_EATT
+	enum bt_att_chan_option chan_option;
+#endif /* CONFIG_BT_EATT */
 };
 
 /** @brief Indicate attribute value change.
@@ -1340,6 +1346,9 @@ struct bt_gatt_discover_params {
 	/** Only for stack-internal use, used for automatic discovery. */
 	struct bt_gatt_subscribe_params *sub_params;
 #endif /* defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC) */
+#ifdef CONFIG_BT_EATT
+	enum bt_att_chan_option chan_option;
+#endif /* CONFIG_BT_EATT */
 };
 
 /** @brief GATT Discover function
@@ -1440,6 +1449,9 @@ struct bt_gatt_read_params {
 			const struct bt_uuid *uuid;
 		} by_uuid;
 	};
+#ifdef CONFIG_BT_EATT
+	enum bt_att_chan_option chan_option;
+#endif /* CONFIG_BT_EATT */
 };
 
 /** @brief Read Attribute Value by handle
@@ -1497,6 +1509,9 @@ struct bt_gatt_write_params {
 	const void *data;
 	/** Length of the data */
 	uint16_t length;
+#ifdef CONFIG_BT_EATT
+	enum bt_att_chan_option chan_option;
+#endif /* CONFIG_BT_EATT */
 };
 
 /** @brief Write Attribute Value by handle
@@ -1672,6 +1687,9 @@ struct bt_gatt_subscribe_params {
 	ATOMIC_DEFINE(flags, BT_GATT_SUBSCRIBE_NUM_FLAGS);
 
 	sys_snode_t node;
+#ifdef CONFIG_BT_EATT
+	enum bt_att_chan_option chan_option;
+#endif /* CONFIG_BT_EATT */
 };
 
 /** @brief Subscribe Attribute Value Notification

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -274,6 +274,7 @@ struct bt_att_req {
 	size_t len;
 #endif /* CONFIG_BT_SMP */
 	void *user_data;
+	enum bt_att_chan_option chan_option;
 };
 
 void att_sent(struct bt_conn *conn, void *user_data);
@@ -290,8 +291,8 @@ struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout);
 void bt_att_req_free(struct bt_att_req *req);
 
 /* Send ATT PDU over a connection */
-int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
-		void *user_data);
+int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb, void *user_data,
+		enum bt_att_chan_option chan_option);
 
 /* Send ATT Request over a connection */
 int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req);
@@ -311,3 +312,10 @@ int bt_eatt_disconnect(struct bt_conn *conn);
  *  @return The found request. NULL if not found.
  */
 struct bt_att_req *bt_att_find_req_by_user_data(struct bt_conn *conn, const void *user_data);
+
+
+#if defined(CONFIG_BT_EATT)
+#define BT_ATT_CHAN_OPTION(params) (params)->chan_option
+#else
+#define BT_ATT_CHAN_OPTION(params) BT_ATT_CHAN_UNENHANCED
+#endif /* CONFIG_BT_EATT */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4338,10 +4338,10 @@ static void gatt_write_rsp(struct bt_conn *conn, uint8_t err, const void *pdu,
 	params->func(conn, err, params);
 }
 
-int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
-				      const void *data, uint16_t length, bool sign,
-				      bt_gatt_complete_func_t func,
-				      void *user_data)
+static int bt_gatt_write_without_response_impl(struct bt_conn *conn, uint16_t handle,
+					       const void *data, uint16_t length, bool sign,
+					       bt_gatt_complete_func_t func, void *user_data,
+					       enum bt_att_chan_option chan_option)
 {
 	struct net_buf *buf;
 	struct bt_att_write_cmd *cmd;
@@ -4385,8 +4385,22 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 
 	BT_DBG("handle 0x%04x length %u", handle, length);
 
-	/* TODO: chan_option */
-	return bt_att_send(conn, buf, func, user_data, BT_ATT_CHAN_ANY);
+	return bt_att_send(conn, buf, func, user_data, chan_option);
+}
+
+int bt_gatt_write_without_rsp(struct bt_conn *conn, struct bt_gatt_write_without_rsp_params *params)
+{
+	return bt_gatt_write_without_response_impl(conn, params->handle, params->data,
+						   params->length, params->sign, params->func,
+						   params->user_data, BT_ATT_CHAN_OPTION(params));
+}
+
+int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle, const void *data,
+				      uint16_t length, bool sign, bt_gatt_complete_func_t func,
+				      void *user_data)
+{
+	return bt_gatt_write_without_response_impl(conn, handle, data, length, sign, func,
+						   user_data, BT_ATT_CHAN_ANY);
 }
 
 static int gatt_exec_encode(struct net_buf *buf, size_t len, void *user_data)

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2052,13 +2052,15 @@ struct notify_data {
 struct nfy_mult_data {
 	bt_gatt_complete_func_t func;
 	void *user_data;
+	enum bt_att_chan_option chan_option;
 };
 
 #define nfy_mult_user_data(buf) \
 	((struct nfy_mult_data *)net_buf_user_data(buf))
-#define nfy_mult_data_match(buf, _func, _user_data) \
-	((nfy_mult_user_data(buf)->func == _func) && \
-	(nfy_mult_user_data(buf)->user_data == _user_data))
+#define nfy_mult_data_match(buf, _func, _user_data, _chan_option)                                  \
+	((nfy_mult_user_data(buf)->func == _func) &&                                               \
+	 (nfy_mult_user_data(buf)->user_data == _user_data) &&                                     \
+	 (nfy_mult_user_data(buf)->chan_option == _chan_option))
 
 static struct net_buf *nfy_mult[CONFIG_BT_MAX_CONN];
 
@@ -2067,7 +2069,7 @@ static int gatt_notify_mult_send(struct bt_conn *conn, struct net_buf **buf)
 	struct nfy_mult_data *data = nfy_mult_user_data(*buf);
 	int ret;
 
-	ret = bt_att_send(conn, *buf, data->func, data->user_data);
+	ret = bt_att_send(conn, *buf, data->func, data->user_data, data->chan_option);
 	if (ret < 0) {
 		net_buf_unref(*buf);
 	}
@@ -2118,7 +2120,8 @@ static int gatt_notify_mult(struct bt_conn *conn, uint16_t handle,
 	 * the existing buffer and proceed to create a new one
 	 */
 	if (*buf && ((net_buf_tailroom(*buf) < sizeof(*nfy) + params->len) ||
-	    !nfy_mult_data_match(*buf, params->func, params->user_data))) {
+		     !nfy_mult_data_match(*buf, params->func, params->user_data,
+					  BT_ATT_CHAN_OPTION(params)))) {
 		int ret;
 
 		ret = gatt_notify_mult_send(conn, buf);
@@ -2136,6 +2139,7 @@ static int gatt_notify_mult(struct bt_conn *conn, uint16_t handle,
 		/* Set user_data so it can be restored when sending */
 		nfy_mult_user_data(*buf)->func = params->func;
 		nfy_mult_user_data(*buf)->user_data = params->user_data;
+		nfy_mult_user_data(*buf)->chan_option = BT_ATT_CHAN_OPTION(params);
 	}
 
 	BT_DBG("handle 0x%04x len %u", handle, params->len);
@@ -2198,7 +2202,7 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 	net_buf_add(buf, params->len);
 	memcpy(nfy->value, params->data, params->len);
 
-	return bt_att_send(conn, buf, params->func, params->user_data);
+	return bt_att_send(conn, buf, params->func, params->user_data, BT_ATT_CHAN_OPTION(params));
 }
 
 static void gatt_indicate_rsp(struct bt_conn *conn, uint8_t err,
@@ -2216,10 +2220,9 @@ static void gatt_indicate_rsp(struct bt_conn *conn, uint8_t err,
 	}
 }
 
-static struct bt_att_req *gatt_req_alloc(bt_att_func_t func, void *params,
-					 bt_att_encode_t encode,
-					 uint8_t op,
-					 size_t len)
+static struct bt_att_req *gatt_req_alloc(bt_att_func_t func, void *params, bt_att_encode_t encode,
+					 uint8_t op, size_t len,
+					 enum bt_att_chan_option chan_option)
 {
 	struct bt_att_req *req;
 
@@ -2237,19 +2240,24 @@ static struct bt_att_req *gatt_req_alloc(bt_att_func_t func, void *params,
 	req->func = func;
 	req->user_data = params;
 
+#if defined(CONFIG_BT_EATT)
+	req->chan_option = chan_option;
+#endif /* CONFIG_BT_EATT */
+
 	return req;
 }
 
 #ifdef CONFIG_BT_GATT_CLIENT
 static int gatt_req_send(struct bt_conn *conn, bt_att_func_t func, void *params,
-			 bt_att_encode_t encode, uint8_t op, size_t len)
+			 bt_att_encode_t encode, uint8_t op, size_t len,
+			 enum bt_att_chan_option chan_option)
 
 {
 	struct bt_att_req *req;
 	struct net_buf *buf;
 	int err;
 
-	req = gatt_req_alloc(func, params, encode, op, len);
+	req = gatt_req_alloc(func, params, encode, op, len, chan_option);
 	if (!req) {
 		return -ENOMEM;
 	}
@@ -2308,8 +2316,8 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 
 	len = sizeof(*ind) + params->len;
 
-	req = gatt_req_alloc(gatt_indicate_rsp, params, NULL,
-			     BT_ATT_OP_INDICATE, len);
+	req = gatt_req_alloc(gatt_indicate_rsp, params, NULL, BT_ATT_OP_INDICATE, len,
+			     BT_ATT_CHAN_OPTION(params));
 	if (!req) {
 		return -ENOMEM;
 	}
@@ -3152,9 +3160,9 @@ int bt_gatt_exchange_mtu(struct bt_conn *conn,
 		return -ENOTCONN;
 	}
 
-	return gatt_req_send(conn, gatt_mtu_rsp, params,
-			     gatt_exchange_mtu_encode, BT_ATT_OP_MTU_REQ,
-			     sizeof(struct bt_att_exchange_mtu_req));
+	return gatt_req_send(conn, gatt_mtu_rsp, params, gatt_exchange_mtu_encode,
+			     BT_ATT_OP_MTU_REQ, sizeof(struct bt_att_exchange_mtu_req),
+			     BT_ATT_CHAN_UNENHANCED);
 }
 
 static void gatt_discover_next(struct bt_conn *conn, uint16_t last_handle,
@@ -3297,9 +3305,8 @@ static int gatt_find_type(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	return gatt_req_send(conn, gatt_find_type_rsp, params,
-			     gatt_find_type_encode, BT_ATT_OP_FIND_TYPE_REQ,
-			     len);
+	return gatt_req_send(conn, gatt_find_type_rsp, params, gatt_find_type_encode,
+			     BT_ATT_OP_FIND_TYPE_REQ, len, BT_ATT_CHAN_OPTION(params));
 }
 
 static void read_included_uuid_cb(struct bt_conn *conn, uint8_t err,
@@ -3365,9 +3372,9 @@ static int read_included_uuid(struct bt_conn *conn,
 {
 	BT_DBG("handle 0x%04x", params->_included.start_handle);
 
-	return gatt_req_send(conn, read_included_uuid_cb, params,
-			     read_included_uuid_encode, BT_ATT_OP_READ_REQ,
-			     sizeof(struct bt_att_read_req));
+	return gatt_req_send(conn, read_included_uuid_cb, params, read_included_uuid_encode,
+			     BT_ATT_OP_READ_REQ, sizeof(struct bt_att_read_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 static uint16_t parse_include(struct bt_conn *conn, const void *pdu,
@@ -3676,9 +3683,9 @@ static int gatt_read_type(struct bt_conn *conn,
 	BT_DBG("start_handle 0x%04x end_handle 0x%04x", params->start_handle,
 	       params->end_handle);
 
-	return gatt_req_send(conn, gatt_read_type_rsp, params,
-			     gatt_read_type_encode, BT_ATT_OP_READ_TYPE_REQ,
-			     sizeof(struct bt_att_read_type_req));
+	return gatt_req_send(conn, gatt_read_type_rsp, params, gatt_read_type_encode,
+			     BT_ATT_OP_READ_TYPE_REQ, sizeof(struct bt_att_read_type_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 static uint16_t parse_service(struct bt_conn *conn, const void *pdu,
@@ -3813,10 +3820,9 @@ static int gatt_read_group(struct bt_conn *conn,
 	BT_DBG("start_handle 0x%04x end_handle 0x%04x", params->start_handle,
 	       params->end_handle);
 
-	return gatt_req_send(conn, gatt_read_group_rsp, params,
-			     gatt_read_group_encode,
-			     BT_ATT_OP_READ_GROUP_REQ,
-			     sizeof(struct bt_att_read_group_req));
+	return gatt_req_send(conn, gatt_read_group_rsp, params, gatt_read_group_encode,
+			     BT_ATT_OP_READ_GROUP_REQ, sizeof(struct bt_att_read_group_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 static void gatt_find_info_rsp(struct bt_conn *conn, uint8_t err,
@@ -3951,9 +3957,9 @@ static int gatt_find_info(struct bt_conn *conn,
 	BT_DBG("start_handle 0x%04x end_handle 0x%04x", params->start_handle,
 	       params->end_handle);
 
-	return gatt_req_send(conn, gatt_find_info_rsp, params,
-			     gatt_find_info_encode, BT_ATT_OP_FIND_INFO_REQ,
-			     sizeof(struct bt_att_find_info_req));
+	return gatt_req_send(conn, gatt_find_info_rsp, params, gatt_find_info_encode,
+			     BT_ATT_OP_FIND_INFO_REQ, sizeof(struct bt_att_find_info_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 int bt_gatt_discover(struct bt_conn *conn,
@@ -4121,9 +4127,9 @@ static int gatt_read_blob(struct bt_conn *conn,
 	BT_DBG("handle 0x%04x offset 0x%04x", params->single.handle,
 	       params->single.offset);
 
-	return gatt_req_send(conn, gatt_read_rsp, params,
-			     gatt_read_blob_encode, BT_ATT_OP_READ_BLOB_REQ,
-			     sizeof(struct bt_att_read_blob_req));
+	return gatt_req_send(conn, gatt_read_rsp, params, gatt_read_blob_encode,
+			     BT_ATT_OP_READ_BLOB_REQ, sizeof(struct bt_att_read_blob_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 static int gatt_read_uuid_encode(struct net_buf *buf, size_t len,
@@ -4152,9 +4158,9 @@ static int gatt_read_uuid(struct bt_conn *conn,
 		params->by_uuid.start_handle, params->by_uuid.end_handle,
 		bt_uuid_str(params->by_uuid.uuid));
 
-	return gatt_req_send(conn, gatt_read_rsp, params,
-			     gatt_read_uuid_encode, BT_ATT_OP_READ_TYPE_REQ,
-			     sizeof(struct bt_att_read_type_req));
+	return gatt_req_send(conn, gatt_read_rsp, params, gatt_read_uuid_encode,
+			     BT_ATT_OP_READ_TYPE_REQ, sizeof(struct bt_att_read_type_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 #if defined(CONFIG_BT_GATT_READ_MULTIPLE)
@@ -4194,9 +4200,9 @@ static int gatt_read_mult(struct bt_conn *conn,
 {
 	BT_DBG("handle_count %zu", params->handle_count);
 
-	return gatt_req_send(conn, gatt_read_mult_rsp, params,
-			     gatt_read_mult_encode, BT_ATT_OP_READ_MULT_REQ,
-			     params->handle_count * sizeof(uint16_t));
+	return gatt_req_send(conn, gatt_read_mult_rsp, params, gatt_read_mult_encode,
+			     BT_ATT_OP_READ_MULT_REQ, params->handle_count * sizeof(uint16_t),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 #if defined(CONFIG_BT_EATT)
@@ -4258,10 +4264,9 @@ static int gatt_read_mult_vl(struct bt_conn *conn,
 {
 	BT_DBG("handle_count %zu", params->handle_count);
 
-	return gatt_req_send(conn, gatt_read_mult_vl_rsp, params,
-			     gatt_read_mult_vl_encode,
-			     BT_ATT_OP_READ_MULT_VL_REQ,
-			     params->handle_count * sizeof(uint16_t));
+	return gatt_req_send(conn, gatt_read_mult_vl_rsp, params, gatt_read_mult_vl_encode,
+			     BT_ATT_OP_READ_MULT_VL_REQ, params->handle_count * sizeof(uint16_t),
+			     BT_ATT_CHAN_OPTION(params));
 }
 #endif /* CONFIG_BT_EATT */
 
@@ -4279,7 +4284,7 @@ static int gatt_read_mult_vl(struct bt_conn *conn,
 {
 	return -ENOTSUP;
 }
-#endif
+#endif /* !defined(CONFIG_BT_GATT_READ_MULTIPLE) || !defined(CONFIG_BT_EATT) */
 
 static int gatt_read_encode(struct net_buf *buf, size_t len, void *user_data)
 {
@@ -4319,9 +4324,8 @@ int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params)
 
 	BT_DBG("handle 0x%04x", params->single.handle);
 
-	return gatt_req_send(conn, gatt_read_rsp, params, gatt_read_encode,
-			     BT_ATT_OP_READ_REQ,
-			     sizeof(struct bt_att_read_req));
+	return gatt_req_send(conn, gatt_read_rsp, params, gatt_read_encode, BT_ATT_OP_READ_REQ,
+			     sizeof(struct bt_att_read_req), BT_ATT_CHAN_OPTION(params));
 }
 
 static void gatt_write_rsp(struct bt_conn *conn, uint8_t err, const void *pdu,
@@ -4381,7 +4385,8 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 
 	BT_DBG("handle 0x%04x length %u", handle, length);
 
-	return bt_att_send(conn, buf, func, user_data);
+	/* TODO: chan_option */
+	return bt_att_send(conn, buf, func, user_data, BT_ATT_CHAN_ANY);
 }
 
 static int gatt_exec_encode(struct net_buf *buf, size_t len, void *user_data)
@@ -4400,8 +4405,8 @@ static int gatt_exec_write(struct bt_conn *conn,
 	BT_DBG("");
 
 	return gatt_req_send(conn, gatt_write_rsp, params, gatt_exec_encode,
-			     BT_ATT_OP_EXEC_WRITE_REQ,
-			     sizeof(struct bt_att_exec_write_req));
+			     BT_ATT_OP_EXEC_WRITE_REQ, sizeof(struct bt_att_exec_write_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 static int gatt_cancel_encode(struct net_buf *buf, size_t len, void *user_data)
@@ -4420,8 +4425,8 @@ static int gatt_cancel_all_writes(struct bt_conn *conn,
 	BT_DBG("");
 
 	return gatt_req_send(conn, gatt_write_rsp, params, gatt_cancel_encode,
-			     BT_ATT_OP_EXEC_WRITE_REQ,
-			     sizeof(struct bt_att_exec_write_req));
+			     BT_ATT_OP_EXEC_WRITE_REQ, sizeof(struct bt_att_exec_write_req),
+			     BT_ATT_CHAN_OPTION(params));
 }
 
 static void gatt_prepare_write_rsp(struct bt_conn *conn, uint8_t err,
@@ -4518,9 +4523,8 @@ static int gatt_prepare_write(struct bt_conn *conn,
 	len = MIN(params->length, len);
 	len += req_len;
 
-	return gatt_req_send(conn, gatt_prepare_write_rsp, params,
-			     gatt_prepare_write_encode,
-			     BT_ATT_OP_PREPARE_WRITE_REQ, len);
+	return gatt_req_send(conn, gatt_prepare_write_rsp, params, gatt_prepare_write_encode,
+			     BT_ATT_OP_PREPARE_WRITE_REQ, len, BT_ATT_CHAN_OPTION(params));
 }
 
 static int gatt_write_encode(struct net_buf *buf, size_t len, void *user_data)
@@ -4562,8 +4566,8 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params)
 
 	BT_DBG("handle 0x%04x length %u", params->handle, params->length);
 
-	return gatt_req_send(conn, gatt_write_rsp, params, gatt_write_encode,
-			     BT_ATT_OP_WRITE_REQ, len);
+	return gatt_req_send(conn, gatt_write_rsp, params, gatt_write_encode, BT_ATT_OP_WRITE_REQ,
+			     len, BT_ATT_CHAN_OPTION(params));
 }
 
 static void gatt_write_ccc_rsp(struct bt_conn *conn, uint8_t err,
@@ -4624,8 +4628,8 @@ static int gatt_write_ccc(struct bt_conn *conn,
 
 	BT_DBG("handle 0x%04x value 0x%04x", params->ccc_handle, params->value);
 
-	return gatt_req_send(conn, gatt_write_ccc_rsp, params,
-			     gatt_write_ccc_buf, BT_ATT_OP_WRITE_REQ, len);
+	return gatt_req_send(conn, gatt_write_ccc_rsp, params, gatt_write_ccc_buf,
+			     BT_ATT_OP_WRITE_REQ, len, BT_ATT_CHAN_OPTION(params));
 }
 
 #if defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC)


### PR DESCRIPTION
Adds API for choosing the type of ATT channel to send GATT packets over. The application can choose to send over unenhanced ATT, enhanced ATT, or let the host choose any ATT channel.

The addition of the write without response function that takes a param struct and deprecation of the existing ones should probably be moved out to a separate PR upstream.